### PR TITLE
Default difficulty and lockout check fix

### DIFF
--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -42,10 +42,14 @@ local raid_patterns_template = {
 };
 
 local function create_pattern_from_template(raid_name_pattern, size, difficulty, full_raid_name)
-	if not raid_name_pattern or not size or not difficulty or not full_raid_name then
+	if not raid_name_pattern or not size or not full_raid_name then
 		return;
 	end
-	
+
+    if not difficulty then
+        difficulty = 'nm'
+    end
+
 	full_raid_name = string.lower(full_raid_name);
 	
 	if size == 10 then
@@ -612,7 +616,7 @@ function raid_browser:OnEnable()
 	raid_browser.lfm_messages = {}
 	raid_browser.timer = raid_browser.set_timer(10, refresh_lfm_messages, true)
 	for channel, listener in pairs(lfm_channel_listeners) do
-		channel_listeners[i] = raid_browser.add_event_listener(channel, event_handler)
+	    table.insert(channel_listeners, raid_browser.add_event_listener(channel, event_handler))
 	end
 	
 	raid_browser.gui.raidset.initialize();

--- a/RaidBrowser/stats.lua
+++ b/RaidBrowser/stats.lua
@@ -105,9 +105,9 @@ end
 function raid_browser.stats.raid_lock_info(instance_name, size)
 	RequestRaidInfo();
 	for i = 1, GetNumSavedInstances() do
-		local saved_name, _, reset, _, _, _, _, _, saved_size = GetSavedInstanceInfo(i);
+		local saved_name, _, reset, _, locked, _, _, _, saved_size = GetSavedInstanceInfo(i);
 		
-		if saved_name == instance_name and saved_size == size then
+		if saved_name == instance_name and saved_size == size and locked then
 			return true, reset;
 		end
 	end


### PR DESCRIPTION
Hello, I don't know if you are still planning on working on this, I had the opportunity to play with your addon for a few weeks now and decided to fix some problems I encountered:

- the lockout info was wrong: if the lockout was expired, the addon still considered the raid as locked
- if the difficulty wasn't detected then the addon skipped the message, now the default difficulty is normal