### PR TITLE
DRAFT: Improve support for Weekly Quest and Achievement run postings

### DIFF
--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -177,6 +177,17 @@ local raid_list = {
 	},
 
 	{
+        name = 'icc10wq',
+        instance_name = 'Icecrown Citadel',
+        size = 10,
+        patterns = {
+            'icc1?0?' .. csep .. 'weekly',
+            'Lord Marrowgar' .. wtext .. '!',
+            create_quest_pattern(24590),
+        },
+    },
+
+	{
 		name = 'icc10nm',
 		instance_name = 'Icecrown Citadel',
 		size = 10,
@@ -189,11 +200,6 @@ local raid_list = {
 				create_achievement_pattern(4530),
 				'Fall of the Lich King %(10 player%)',
 				create_achievement_pattern(4532),
-
-				-- weekly
-				'icc1?0?' .. csep .. 'weekly',
-				'Lord Marrowgar' .. wtext .. '!',
-				create_quest_pattern(24590),
 			}
 		)
 	},
@@ -244,6 +250,17 @@ local raid_list = {
 	},
 
 	{
+		name = 'toc10wq',
+		instance_name = 'Trial of the Crusader',
+		size = 10,
+		patterns = {
+			'tog?c1?0?' .. csep .. 'weekly',
+			'Lord Jaraxxus' .. wtext .. '!',
+			create_quest_pattern(24589),
+		},
+	},
+
+	{
 		name = 'toc10nm',
 		instance_name = 'Trial of the Crusader',
 		size = 10,
@@ -252,11 +269,6 @@ local raid_list = {
 			{ 
 				'Call of the Crusade %(10 player%)',
 				create_achievement_pattern(3917),
-
-				-- weekly
-				'tog?c1?0?' .. csep .. 'weekly',
-				'Lord Jaraxxus' .. wtext .. '!',
-				create_quest_pattern(24589),
 			}
 		),
 	},
@@ -281,7 +293,7 @@ local raid_list = {
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('rs', 10, 'hc'),
 			{
-				'ruby' .. csep .. 'sanctum' .. csep .. 10,
+				'ruby' .. csep .. 'sanctum' .. csep .. '10' .. wtext .. 'hc',
 				'Heroic: The Twilight Destroyer %(10 player%)',
 				create_achievement_pattern(4818),
 			}
@@ -295,6 +307,7 @@ local raid_list = {
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('rs', 25, 'hc'),
 			{
+				'ruby' .. csep .. 'sanctum' .. csep .. '25' .. wtext .. 'hc',
 				'Heroic: The Twilight Destroyer %(25 player%)',
 				create_achievement_pattern(4816),
 			}
@@ -308,7 +321,7 @@ local raid_list = {
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('rs', 10, 'nm'),
 			{
-				'ruby' .. csep .. 'sanctum' .. csep .. 10,
+				'ruby' .. csep .. 'sanctum' .. csep .. '10',
 				'The Twilight Destroyer %(10 player%)',
 				create_achievement_pattern(4817),
 			}
@@ -322,7 +335,7 @@ local raid_list = {
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('rs', 25, 'nm'),
 			{
-				'ruby' .. csep .. 'sanctum' .. csep .. 25,
+				'ruby' .. csep .. 'sanctum' .. csep .. '25',
 				'The Twilight Destroyer %(25 player%)',
 				create_achievement_pattern(4815),
 			}
@@ -344,15 +357,10 @@ local raid_list = {
 	},
 
 	{
-		name = 'ulduar10',
+		name = 'ulduar10wq',
 		instance_name = 'Ulduar',
 		size = 10,
 		patterns = {
-			'ull?a?d[au]?[au]?r?' .. csep .. '10',
-			'The Siege of Ulduar %(10 player%)',
-			create_achievement_pattern(2886),
-
-			-- weekly
 			'ull?a?d[au]?[au]?r?1?0?' .. csep .. 'weekly',
 			'Flame Leviathan' .. wtext .. '!',
 			create_quest_pattern(24585),
@@ -362,6 +370,17 @@ local raid_list = {
 			create_quest_pattern(24586),
 			'XT-002' .. wtext .. '!',
 			create_quest_pattern(24588),
+		},
+	},
+
+	{
+		name = 'ulduar10',
+		instance_name = 'Ulduar',
+		size = 10,
+		patterns = {
+			'ull?a?d[au]?[au]?r?' .. csep .. '10',
+			'The Siege of Ulduar %(10 player%)',
+			create_achievement_pattern(2886),
 		},
 	},
 
@@ -377,6 +396,17 @@ local raid_list = {
 	},
 
 	{
+		name = 'os10wq',
+		instance_name = 'The Obsidian Sanctum',
+		size = 10,
+		patterns = {
+			'os1?0?' .. csep .. 'weekly',
+			'Sartharion' .. wtext .. '!',
+			create_quest_pattern(24579),
+		}
+	},
+
+	{
 		name = 'os10',
 		instance_name = 'The Obsidian Sanctum',
 		size = 10,
@@ -385,11 +415,6 @@ local raid_list = {
 			{ 
 				'Besting the Black Dragonflight %(10 player%)',
 				create_achievement_pattern(1876),
-
-				-- weekly
-				'os1?0?' .. csep .. 'weekly',
-				'Sartharion' .. wtext .. '!',
-				create_quest_pattern(24579),
 			}
 		),
 	},
@@ -408,16 +433,10 @@ local raid_list = {
 	},
 
 	{
-		name = 'naxx10',
+		name = 'naxx10wq',
 		instance_name = 'Naxxramas',
 		size = 10,
 		patterns = {
-			'The Fall of Naxxramas %(10 player%)',
-			create_achievement_pattern(576),
-			'naxx?ramm?as' .. csep .. '10',
-			'naxx?' .. csep .. '10',
-
-			-- weekly
 			'naxx?1?0?' .. csep .. 'weekly',
 			'Anub\'Rekhan' .. wtext .. '!',
 			create_quest_pattern(24580),
@@ -427,6 +446,18 @@ local raid_list = {
 			create_quest_pattern(24582),
 			'Patchwerk' .. wtext .. '!',
 			create_quest_pattern(24583),
+		},
+	},
+
+	{
+		name = 'naxx10',
+		instance_name = 'Naxxramas',
+		size = 10,
+		patterns = {
+			'The Fall of Naxxramas %(10 player%)',
+			create_achievement_pattern(576),
+			'naxx?ramm?as' .. csep .. '10',
+			'naxx?' .. csep .. '10',
 		},
 	},
 
@@ -443,6 +474,17 @@ local raid_list = {
 	},
 
 	{
+		name = 'eoe10wq',
+		instance_name = 'The Eye of Eternity',
+		size = 10,
+		patterns = {
+			'eoe1?0?' .. csep .. 'weekly',
+			'Malygos' .. wtext .. '!',
+			create_quest_pattern(24584),
+		},
+	},
+
+	{
 		name = 'eoe10',
 		instance_name = 'The Eye of Eternity',
 		size = 10,
@@ -453,11 +495,6 @@ local raid_list = {
 				'eoe' .. csep .. '10',
 				'A Poke In The Eye %(10 player%)',
 				create_achievement_pattern(1869),
-
-				-- weekly
-				'eoe1?0?' .. csep .. 'weekly',
-				'Malygos' .. wtext .. '!',
-				create_quest_pattern(24584),
 			}
 		),
 	},
@@ -650,16 +687,12 @@ local raid_list = {
 local role_patterns = {
 	dps = {
 
-		'feral' .. csep .. 'cat' .. sep,
-		'feral' .. csep .. 'd?p?s?',
+		're?t?r?i?b?u?t?i?o?n?' .. csep .. 'pal[al]?[dy]?i?n?',
+		'fury',
 
-		'ret' .. csep .. 'pal[al]?[dy]?i?n?',
-
-		'shadow' .. csep .. 'pri?e?st',
+		'sh?a?d?o?w?' .. csep .. 'pri?e?st',
 		'pri?e?st' .. csep .. 'dps',
 		'sp',
-
-		'balance' .. '[ru][ud][iu]d?',
 
 		'elem?e?n?t?a?l?' .. csep .. 'shamm?[iy]?',
 		'mage',
@@ -669,18 +702,18 @@ local role_patterns = {
 		'boo?mi',
 		'boo?my',
 		'owl',
+		'ba?l?a?n?c?e?' .. csep .. 'd[ru][ud][iu]d?',
 
-		'b[ru][ud][iu]d?',
-
-		'rogue' .. meta_or_sep,
-		'rouge' .. meta_or_sep,
+		'rogu?e?' .. meta_or_sep,
+		'roug?e?' .. meta_or_sep,
 
 		'kitt?y',
 		'cat',
+		'feral' .. csep .. 'cat' .. sep,
+		'feral' .. csep .. 'd?p?s?',
 
 		'w?a?r?lock',
-
-		'spri?e?st',
+		'demol?i?t?i?o?n?',
 
 		'hunte?r?s?',
 
@@ -690,26 +723,21 @@ local role_patterns = {
 	},
 
 	healer = {
-		'h[ea][ea]l[ers]*', -- LF healer
-		'heler',
+		'h[ea][ea]?l[ers]*', -- LF healer
 
-		'resto' .. csep .. 'd[ru][ud][iu]d?', -- LF rdruid/rdudu
-		'rd[ru][ud][iu]d?', -- LF rdruid/rdudu
+		're?s?t?o?' .. csep .. 'd[ru][ud][iu]d?', -- LF rdruid/rdudu
 		meta_or_sep .. 'r' .. csep .. 'd[ru][ud][iu]d?', -- LF rdruid/rdudu
-
 		'tree', -- LF tree
 
-		'resto' .. csep .. 'shamm?y?', -- LF rsham
-		'rshamm?y?', -- LF rsham
+		're?s?t?o?' .. csep .. 'shamm?y?', -- LF rsham
 		meta_or_sep .. 'r' .. csep .. 'shamm?y?', -- LF rsham
 
 		'disco?' .. csep .. 'pri?e?st', -- disc priest
 		'dpri?e?st', -- disc priest
 		meta_or_sep .. 'd' .. csep .. 'pri?e?st', -- disc priest
 
-		'holl?y' .. csep .. 'palad?i?n?', -- LF holy pala
-		'hpala?d?i?n?', -- LF hpala
-		meta_or_sep .. 'h' .. csep .. 'palad?i?n?', -- LF hpala
+		'ho?l?l?y?' .. csep .. 'pala?d?i?n?', -- LF holy pala
+		meta_or_sep .. 'h' .. csep .. 'pala?d?i?n?', -- LF hpala
 	},
 
 	tank = {
@@ -717,7 +745,7 @@ local role_patterns = {
 		role_sep .. '[mo]t' .. csep .. '$', -- Need MT/OT
 		'ta*n+a?k+s?', -- NEED TANKS
 		'b[ea]*rs?',
-		'prot' .. csep .. 'pal[al]?[dy]?i?n?',
+		'prote?c?t?i?o?n?', -- NEED PROT PALA/WARRI
 	},
 }
 
@@ -975,8 +1003,11 @@ function RaidBrowser.lex_raid_info(message)
 		end);
 
 		if index then
-			num_unique_raids = num_unique_raids + 1;
-			raid = r;
+			-- only count as new unique raid, if previously found raid was a different size or zone
+			if not raid or (raid.size ~= r.size or RaidBrowser.get_short_raid_name(r.name) ~= RaidBrowser.get_short_raid_name(raid.name)) then
+				num_unique_raids = num_unique_raids + 1;
+				raid = r;
+			end
 		end
 	end
 

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -150,6 +150,7 @@ local raid_list = {
 				'Heroic: Storming the Citadel %(10 player%)',
 				create_achievement_pattern(4628),
 				'Bane of the Fallen King',
+				'[^a-z]Bane[^a-z]',
 				create_achievement_pattern(4583),
 				'Heroic: Fall of the Lich King %(10 player%)',
 				create_achievement_pattern(4636),
@@ -167,6 +168,7 @@ local raid_list = {
 				'Heroic: Storming the Citadel %(25 player%)',
 				create_achievement_pattern(4632),
 				'The Light of Dawn',
+				'[^a-z]LoD[^a-z]',
 				create_achievement_pattern(4584),
 				'Heroic: Fall of the Lich King %(25 player%)',
 				create_achievement_pattern(4637),
@@ -792,23 +794,23 @@ local lfm_patterns = {
 
 	lfm .. csep .. '[0-9]*' .. csep .. meta_role .. non_meta .. meta_gs .. '.*' .. meta_raid,
 	lfm .. csep .. 'all' .. non_meta .. meta_raid,
-	'need' .. csep .. 'all' .. non_meta .. meta_raid,
+	'nee?d' .. csep .. 'all' .. non_meta .. meta_raid,
 	'seek' .. csep .. 'all' .. non_meta .. meta_raid,
 
 	meta_raid .. non_meta .. lfm .. csep .. 'all',
-	meta_raid .. non_meta .. 'need' .. csep .. 'all',
+	meta_raid .. non_meta .. 'nee?d' .. csep .. 'all',
 	meta_raid .. non_meta .. meta_gs .. non_meta .. 'lf' .. csep .. 'all',
 	meta_raid .. non_meta .. meta_gs .. non_meta .. 'seek' .. csep .. 'all',
-	meta_raid .. non_meta .. meta_gs .. non_meta .. 'need' .. csep .. 'all',
+	meta_raid .. non_meta .. meta_gs .. non_meta .. 'nee?d' .. csep .. 'all',
 
 	meta_raid .. non_meta .. meta_role .. non_meta .. meta_gs,
-	meta_raid .. non_meta .. 'need' .. non_meta .. meta_role,
+	meta_raid .. non_meta .. 'nee?d' .. non_meta .. meta_role,
 	meta_raid .. non_meta .. 'seek' .. non_meta .. meta_role,
 
 	meta_raid .. non_meta .. lfm .. non_meta .. meta_role,
 	meta_raid .. non_meta .. 'looki?ng' .. csep .. 'for' .. non_meta .. meta_role,
 
-	meta_raid .. non_meta .. 'need' .. csep .. 'all',
+	meta_raid .. non_meta .. 'nee?d' .. csep .. 'all',
 
 	meta_raid .. non_meta .. meta_gs .. non_meta .. meta_role,
 
@@ -1073,7 +1075,7 @@ function RaidBrowser.lex_and_extract(message)
 	-- Get any roles that are needed
 	local roles = {};
 
-	if not raid_lexed_message:find('lfm? all ') and not raid_lexed_message:find('need all ') then
+	if not raid_lexed_message:find('lfm? all ') and not raid_lexed_message:find('nee?d all ') then
 		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'dps');
 		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'tank');
 		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'healer');

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -177,17 +177,6 @@ local raid_list = {
 	},
 
 	{
-		name = 'icc10wq',
-		instance_name = 'Icecrown Citadel',
-		size = 10,
-		patterns = {
-			'icc1?0?' .. csep .. 'weekly',
-			'Lord Marrowgar' .. wtext .. '!',
-			create_quest_pattern(24590),
-		},
-	},
-
-	{
 		name = 'icc10nm',
 		instance_name = 'Icecrown Citadel',
 		size = 10,
@@ -200,6 +189,11 @@ local raid_list = {
 				create_achievement_pattern(4530),
 				'Fall of the Lich King %(10 player%)',
 				create_achievement_pattern(4532),
+
+				-- weekly
+				'icc1?0?' .. csep .. 'weekly',
+				'Lord Marrowgar' .. wtext .. '!',
+				create_quest_pattern(24590),
 			}
 		)
 	},
@@ -250,17 +244,6 @@ local raid_list = {
 	},
 
 	{
-		name = 'toc10wq',
-		instance_name = 'Trial of the Crusader',
-		size = 10,
-		patterns = {
-			'tog?c1?0?' .. csep .. 'weekly',
-			'Lord Jaraxxus' .. wtext .. '!',
-			create_quest_pattern(24589),
-		},
-	},
-
-	{
 		name = 'toc10nm',
 		instance_name = 'Trial of the Crusader',
 		size = 10,
@@ -269,6 +252,11 @@ local raid_list = {
 			{ 
 				'Call of the Crusade %(10 player%)',
 				create_achievement_pattern(3917),
+
+				-- weekly
+				'tog?c1?0?' .. csep .. 'weekly',
+				'Lord Jaraxxus' .. wtext .. '!',
+				create_quest_pattern(24589),
 			}
 		),
 	},
@@ -356,10 +344,15 @@ local raid_list = {
 	},
 
 	{
-		name = 'ulduar10wq',
+		name = 'ulduar10',
 		instance_name = 'Ulduar',
 		size = 10,
 		patterns = {
+			'ull?a?d[au]?[au]?r?' .. csep .. '10',
+			'The Siege of Ulduar %(10 player%)',
+			create_achievement_pattern(2886),
+
+			-- weekly
 			'ull?a?d[au]?[au]?r?1?0?' .. csep .. 'weekly',
 			'Flame Leviathan' .. wtext .. '!',
 			create_quest_pattern(24585),
@@ -369,17 +362,6 @@ local raid_list = {
 			create_quest_pattern(24586),
 			'XT-002' .. wtext .. '!',
 			create_quest_pattern(24588),
-		},
-	},
-
-	{
-		name = 'ulduar10',
-		instance_name = 'Ulduar',
-		size = 10,
-		patterns = {
-			'ull?a?d[au]?[au]?r?' .. csep .. '10',
-			'The Siege of Ulduar %(10 player%)',
-			create_achievement_pattern(2886),
 		},
 	},
 
@@ -395,17 +377,6 @@ local raid_list = {
 	},
 
 	{
-		name = 'os10wq',
-		instance_name = 'The Obsidian Sanctum',
-		size = 10,
-		patterns = {
-			'os1?0?' .. csep .. 'weekly',
-			'Sartharion' .. wtext .. '!',
-			create_quest_pattern(24579),
-		}
-	},
-
-	{
 		name = 'os10',
 		instance_name = 'The Obsidian Sanctum',
 		size = 10,
@@ -414,6 +385,11 @@ local raid_list = {
 			{ 
 				'Besting the Black Dragonflight %(10 player%)',
 				create_achievement_pattern(1876),
+
+				-- weekly
+				'os1?0?' .. csep .. 'weekly',
+				'Sartharion' .. wtext .. '!',
+				create_quest_pattern(24579),
 			}
 		),
 	},
@@ -432,10 +408,16 @@ local raid_list = {
 	},
 
 	{
-		name = 'naxx10wq',
+		name = 'naxx10',
 		instance_name = 'Naxxramas',
 		size = 10,
 		patterns = {
+			'The Fall of Naxxramas %(10 player%)',
+			create_achievement_pattern(576),
+			'naxx?ramm?as' .. csep .. '10',
+			'naxx?' .. csep .. '10',
+
+			-- weekly
 			'naxx?1?0?' .. csep .. 'weekly',
 			'Anub\'Rekhan' .. wtext .. '!',
 			create_quest_pattern(24580),
@@ -445,18 +427,6 @@ local raid_list = {
 			create_quest_pattern(24582),
 			'Patchwerk' .. wtext .. '!',
 			create_quest_pattern(24583),
-		},
-	},
-
-	{
-		name = 'naxx10',
-		instance_name = 'Naxxramas',
-		size = 10,
-		patterns = {
-			'The Fall of Naxxramas %(10 player%)',
-			create_achievement_pattern(576),
-			'naxx?ramm?as' .. csep .. '10',
-			'naxx?' .. csep .. '10',
 		},
 	},
 
@@ -473,17 +443,6 @@ local raid_list = {
 	},
 
 	{
-		name = 'eoe10wq',
-		instance_name = 'The Eye of Eternity',
-		size = 10,
-		patterns = {
-			'eoe1?0?' .. csep .. 'weekly',
-			'Malygos' .. wtext .. '!',
-			create_quest_pattern(24584),
-		},
-	},
-
-	{
 		name = 'eoe10',
 		instance_name = 'The Eye of Eternity',
 		size = 10,
@@ -494,6 +453,11 @@ local raid_list = {
 				'eoe' .. csep .. '10',
 				'A Poke In The Eye %(10 player%)',
 				create_achievement_pattern(1869),
+
+				-- weekly
+				'eoe1?0?' .. csep .. 'weekly',
+				'Malygos' .. wtext .. '!',
+				create_quest_pattern(24584),
 			}
 		),
 	},
@@ -518,9 +482,9 @@ local raid_list = {
 		instance_name = 'Onyxia\'s Lair',
 		size = 25,
 		patterns = {
+			'onyx?i?a?' .. csep .. '25',
 			'Onyxia\'s Lair %(25 player%)',
 			create_achievement_pattern(4397),
-			'onyx?i?a?' .. csep .. '25',
 		},
 	},
 
@@ -529,9 +493,9 @@ local raid_list = {
 		instance_name = 'Onyxia\'s Lair',
 		size = 10,
 		patterns = {
+			'onyx?i?a?' .. csep .. '10',
 			'Onyxia\'s Lair %(10 player%)',
 			create_achievement_pattern(4396),
-			'onyx?i?a?' .. csep .. '10',
 		},
 	},
 

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -177,17 +177,6 @@ local raid_list = {
 	},
 
 	{
-        name = 'icc10wq',
-        instance_name = 'Icecrown Citadel',
-        size = 10,
-        patterns = {
-            'icc1?0?' .. csep .. 'weekly',
-            'Lord Marrowgar' .. wtext .. '!',
-            create_quest_pattern(24590),
-        },
-    },
-
-	{
 		name = 'icc10nm',
 		instance_name = 'Icecrown Citadel',
 		size = 10,
@@ -222,6 +211,17 @@ local raid_list = {
 	},
 
 	{
+        name = 'icc10wq',
+        instance_name = 'Icecrown Citadel',
+        size = 10,
+        patterns = {
+            'icc1?0?' .. csep .. 'weekly',
+            'Lord Marrowgar' .. wtext .. '!',
+            create_quest_pattern(24590),
+        },
+    },
+
+	{
 		name = 'toc10hc',
 		instance_name = 'Trial of the Crusader',
 		size = 10,
@@ -250,17 +250,6 @@ local raid_list = {
 	},
 
 	{
-		name = 'toc10wq',
-		instance_name = 'Trial of the Crusader',
-		size = 10,
-		patterns = {
-			'tog?c1?0?' .. csep .. 'weekly',
-			'Lord Jaraxxus' .. wtext .. '!',
-			create_quest_pattern(24589),
-		},
-	},
-
-	{
 		name = 'toc10nm',
 		instance_name = 'Trial of the Crusader',
 		size = 10,
@@ -284,6 +273,17 @@ local raid_list = {
 				create_achievement_pattern(3916),
 			}
 		),
+	},
+
+	{
+		name = 'toc10wq',
+		instance_name = 'Trial of the Crusader',
+		size = 10,
+		patterns = {
+			'tog?c1?0?' .. csep .. 'weekly',
+			'Lord Jaraxxus' .. wtext .. '!',
+			create_quest_pattern(24589),
+		},
 	},
 
 	{
@@ -357,23 +357,6 @@ local raid_list = {
 	},
 
 	{
-		name = 'ulduar10wq',
-		instance_name = 'Ulduar',
-		size = 10,
-		patterns = {
-			'ull?a?d[au]?[au]?r?1?0?' .. csep .. 'weekly',
-			'Flame Leviathan' .. wtext .. '!',
-			create_quest_pattern(24585),
-			'Ignis' .. wtext .. '!',
-			create_quest_pattern(24587),
-			'Razorscale' .. wtext .. '!',
-			create_quest_pattern(24586),
-			'XT-002' .. wtext .. '!',
-			create_quest_pattern(24588),
-		},
-	},
-
-	{
 		name = 'ulduar10',
 		instance_name = 'Ulduar',
 		size = 10,
@@ -396,14 +379,20 @@ local raid_list = {
 	},
 
 	{
-		name = 'os10wq',
-		instance_name = 'The Obsidian Sanctum',
+		name = 'ulduar10wq',
+		instance_name = 'Ulduar',
 		size = 10,
 		patterns = {
-			'os1?0?' .. csep .. 'weekly',
-			'Sartharion' .. wtext .. '!',
-			create_quest_pattern(24579),
-		}
+			'ull?a?d[au]?[au]?r?1?0?' .. csep .. 'weekly',
+			'Flame Leviathan' .. wtext .. '!',
+			create_quest_pattern(24585),
+			'Ignis' .. wtext .. '!',
+			create_quest_pattern(24587),
+			'Razorscale' .. wtext .. '!',
+			create_quest_pattern(24586),
+			'XT-002' .. wtext .. '!',
+			create_quest_pattern(24588),
+		},
 	},
 
 	{
@@ -433,20 +422,14 @@ local raid_list = {
 	},
 
 	{
-		name = 'naxx10wq',
-		instance_name = 'Naxxramas',
+		name = 'os10wq',
+		instance_name = 'The Obsidian Sanctum',
 		size = 10,
 		patterns = {
-			'naxx?1?0?' .. csep .. 'weekly',
-			'Anub\'Rekhan' .. wtext .. '!',
-			create_quest_pattern(24580),
-			'Noth' .. wtext .. '!',
-			create_quest_pattern(24581),
-			'Razuvious' .. wtext .. '!',
-			create_quest_pattern(24582),
-			'Patchwerk' .. wtext .. '!',
-			create_quest_pattern(24583),
-		},
+			'os1?0?' .. csep .. 'weekly',
+			'Sartharion' .. wtext .. '!',
+			create_quest_pattern(24579),
+		}
 	},
 
 	{
@@ -474,13 +457,19 @@ local raid_list = {
 	},
 
 	{
-		name = 'eoe10wq',
-		instance_name = 'The Eye of Eternity',
+		name = 'naxx10wq',
+		instance_name = 'Naxxramas',
 		size = 10,
 		patterns = {
-			'eoe1?0?' .. csep .. 'weekly',
-			'Malygos' .. wtext .. '!',
-			create_quest_pattern(24584),
+			'naxx?1?0?' .. csep .. 'weekly',
+			'Anub\'Rekhan' .. wtext .. '!',
+			create_quest_pattern(24580),
+			'Noth' .. wtext .. '!',
+			create_quest_pattern(24581),
+			'Razuvious' .. wtext .. '!',
+			create_quest_pattern(24582),
+			'Patchwerk' .. wtext .. '!',
+			create_quest_pattern(24583),
 		},
 	},
 
@@ -512,6 +501,17 @@ local raid_list = {
 				create_achievement_pattern(1870),
 			}
 		),
+	},
+
+	{
+		name = 'eoe10wq',
+		instance_name = 'The Eye of Eternity',
+		size = 10,
+		patterns = {
+			'eoe1?0?' .. csep .. 'weekly',
+			'Malygos' .. wtext .. '!',
+			create_quest_pattern(24584),
+		},
 	},
 
 	{
@@ -1006,8 +1006,9 @@ function RaidBrowser.lex_raid_info(message)
 			-- only count as new unique raid, if previously found raid was a different size or zone
 			if not raid or (raid.size ~= r.size or RaidBrowser.get_short_raid_name(r.name) ~= RaidBrowser.get_short_raid_name(raid.name)) then
 				num_unique_raids = num_unique_raids + 1;
-				raid = r;
 			end
+			-- but return last found raid to favor nm difficulty (hc achievements are often posted for nm raids, because once u have hc u cannot post the nm) and wq raids
+			raid = r;
 		end
 	end
 
@@ -1110,7 +1111,7 @@ function RaidBrowser.raid_info(message)
 end
 
 function RaidBrowser.get_short_raid_name(raid_name)
-	return string.gsub(raid_name, '[1|2][0|5](%w+)', '');
+	return string.gsub(raid_name, '[1|2][0|5](%w*)', '');
 end
 
 --[[ Event handlers and listeners ]] --

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -542,6 +542,7 @@ local raid_list = {
 		patterns = {
 			'mount' .. csep .. 'hyjal',
 			'the' .. csep .. 'battle' .. csep .. 'for' .. csep .. 'mount' .. csep .. 'hyjal',
+			create_achievement_pattern(695),
 		},
 	},
 
@@ -551,6 +552,7 @@ local raid_list = {
 		size = 10,
 		patterns = {
 			'zul' .. csep .. '\'?' .. csep .. 'aman',
+			create_achievement_pattern(691),
 		},
 	},
 
@@ -562,6 +564,7 @@ local raid_list = {
 			'te*mpe*st' .. csep .. 'ke+p',
 			sep .. 'tk',
 			'tk' .. sep,
+			create_achievement_pattern(696),
 		},
 	},
 
@@ -573,6 +576,7 @@ local raid_list = {
 			'karaz?h?a?n?' .. csep .. '1?0?', -- karazhan
 			'^kz' .. csep .. '10',
 			sep .. 'kz' .. csep .. '10',
+			create_achievement_pattern(690),
 		},
 	},
 
@@ -582,6 +586,7 @@ local raid_list = {
 		size = 25,
 		patterns = {
 			'magt?h?e?r?i?d?o?n?\'*s*' .. csep .. 'lai?r',
+			create_achievement_pattern(693),
 		},
 	},
 
@@ -591,6 +596,7 @@ local raid_list = {
 		size = 25,
 		patterns = {
 			'gruul\'*s*' .. csep .. 'l?a?i?r?',
+			create_achievement_pattern(692),
 		},
 	},
 
@@ -599,7 +605,10 @@ local raid_list = {
 		instance_name = 'Blackwing Lair',
 		size = 40,
 		patterns = {
-			'gruul\'*s*' .. csep .. 'l?a?i?r?',
+			sep .. 'bwl4?0?',
+			'blackwing' .. csep .. 'l?a?i?r?',
+			'blackwi?n?g?' .. csep .. 'la?i?r?',
+			create_achievement_pattern(685),
 		},
 	},
 
@@ -610,6 +619,7 @@ local raid_list = {
 		patterns = {
 			'molte?n' .. csep .. 'core?',
 			sep .. 'mc' .. csep .. '4?0?' .. sep,
+			create_achievement_pattern(686),
 		},
 	},
 
@@ -620,6 +630,7 @@ local raid_list = {
 		patterns = {
 			'black' .. csep .. 'temple',
 			'[%s-_,.]+bt' .. csep .. '25[%s-_,.]+',
+			create_achievement_pattern(697),
 		},
 	},
 
@@ -631,6 +642,7 @@ local raid_list = {
 			'sunwell' .. csep .. 'plateau',
 			'swp' .. sep,
 			sep .. 'swp',
+			create_achievement_pattern(698),
 		},
 	},
 
@@ -644,6 +656,7 @@ local raid_list = {
 			'ssc' .. sep,
 			'ssc' .. csep .. '$',
 			'serpent' .. csep .. 'shrine' .. csep .. 'cavern',
+			create_achievement_pattern(694),
 		},
 	},
 
@@ -654,6 +667,7 @@ local raid_list = {
 		patterns = {
 			'temple?' .. csep .. 'of?' .. csep .. 'ahn\'?' .. csep .. 'qiraj',
 			sep .. '*aq' .. csep .. '40' .. csep .. '',
+			create_achievement_pattern(687),
 		},
 	},
 
@@ -664,6 +678,7 @@ local raid_list = {
 		patterns = {
 			'ruins?' .. csep .. 'of?' .. csep .. 'ahn\'?' .. csep .. 'qiraj',
 			'aq' .. csep .. '20',
+			create_achievement_pattern(689),
 		},
 	},
 

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -681,18 +681,6 @@ local raid_list = {
 			create_achievement_pattern(689),
 		},
 	},
-
-	-- WEEKLY raid fallback
-	{
-		name = 'weekly',
-		instance_name = 'Weekly Quest',
-		size = 10,
-		patterns = {
-			'weekly',
-			'we?ek?l?y?' .. csep .. 'raid',
-			'we?ek?l?y?' .. csep .. 'qu?e?s?t?',
-		},
-	},
 }
 
 local role_patterns = {

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -51,13 +51,13 @@ local raid_patterns_template = {
 		'<raid>' .. csep .. '<size>' .. csep .. 'm?a?n?' .. csep .. 'f?u?l?l?' .. csep .. 'hc?',
 		sep .. 'hc?' .. csep .. '<raid>' .. csep .. '<size>',
 		'<raid>' .. csep .. 'hc?' .. csep .. '<size>',
-		sep .. '<size>' .. csep .. 'ma?n?' .. csep .. '<raid>' .. sep,
+		sep .. '<size>' .. csep .. 'ma?n?' .. csep .. '<raid>' .. csep .. 'hc?'.. sep,
 
-		'^<size>' .. csep .. '<raid>' .. sep,
+		'^<size>' .. csep .. '<raid>' .. csep .. 'hc?'.. sep,
 	},
 
 	nm = {
-		'<raid>' .. csep .. '<size>' .. csep .. 'm?a?n?' .. csep .. 'f?u?l?l?' .. csep .. 'n?m?' .. csep,
+		'<raid>' .. csep .. '<size>' .. csep .. 'm?a?n?' .. csep .. 'f?u?l?l?' .. csep .. 'n?m?' .. sep,
 		sep .. 'nm?' .. csep .. '<raid>' .. csep .. '<size>',
 		'<raid>' .. csep .. 'n?m?' .. csep .. '<size>',
 		sep .. '<size>' .. csep .. 'ma?n?' .. csep .. '<raid>' .. sep,
@@ -80,13 +80,11 @@ local raid_patterns_template = {
 ---@nodiscard
 local function create_pattern_from_template(raid_name_pattern, size, difficulty)
 
-	local size_pattern = '1[0p]'
-	if size == 10 then
-		size_pattern = '1[0o]';
-	elseif size == 25 then
-		size_pattern = '2[5p]';
+	local size_pattern = '1[0Op]+'
+	if size == 25 then
+		size_pattern = '2[5p]+';
 	elseif size == 40 then
-		size_pattern = '4[0p]';
+		size_pattern = '4[0Op]+';
 	end
 
 	if not difficulty then
@@ -212,11 +210,12 @@ local raid_list = {
 
 	{
         name = 'icc10wq',
+		prioritized = true,
         instance_name = 'Icecrown Citadel',
         size = 10,
         patterns = {
             'icc1?0?' .. csep .. 'weekly',
-            'Lord Marrowgar' .. wtext .. '!',
+            'Lord Marrowgar' .. wtext .. '[!%]]',
             create_quest_pattern(24590),
         },
     },
@@ -277,11 +276,12 @@ local raid_list = {
 
 	{
 		name = 'toc10wq',
+		prioritized = true,
 		instance_name = 'Trial of the Crusader',
 		size = 10,
 		patterns = {
 			'tog?c1?0?' .. csep .. 'weekly',
-			'Lord Jaraxxus' .. wtext .. '!',
+			'Lord Jaraxxus' .. wtext .. '[!%]]',
 			create_quest_pattern(24589),
 		},
 	},
@@ -353,7 +353,11 @@ local raid_list = {
 		name = 'voa25',
 		instance_name = 'Vault of Archavon',
 		size = 25,
-		patterns = create_pattern_from_template('voa', 25, 'simple'),
+		patterns = std.algorithm.copy_back(
+			create_pattern_from_template('voa', 25, 'simple'),
+			{
+				'voa' .. sep
+			})
 	},
 
 	{
@@ -380,17 +384,18 @@ local raid_list = {
 
 	{
 		name = 'ulduar10wq',
+		prioritized = true,
 		instance_name = 'Ulduar',
 		size = 10,
 		patterns = {
 			'ull?a?d[au]?[au]?r?1?0?' .. csep .. 'weekly',
-			'Flame Leviathan' .. wtext .. '!',
+			'Flame Leviathan' .. wtext .. '[!%]]',
 			create_quest_pattern(24585),
-			'Ignis' .. wtext .. '!',
+			'Ignis' .. wtext .. '[!%]]',
 			create_quest_pattern(24587),
-			'Razorscale' .. wtext .. '!',
+			'Razorscale' .. wtext .. '[!%]]',
 			create_quest_pattern(24586),
-			'XT-002' .. wtext .. '!',
+			'XT-002' .. wtext .. '[!%]]',
 			create_quest_pattern(24588),
 		},
 	},
@@ -423,11 +428,12 @@ local raid_list = {
 
 	{
 		name = 'os10wq',
+		prioritized = true,
 		instance_name = 'The Obsidian Sanctum',
 		size = 10,
 		patterns = {
 			'os1?0?' .. csep .. 'weekly',
-			'Sartharion' .. wtext .. '!',
+			'Sartharion' .. wtext .. '[!%]]',
 			create_quest_pattern(24579),
 		}
 	},
@@ -458,34 +464,20 @@ local raid_list = {
 
 	{
 		name = 'naxx10wq',
+		prioritized = true,
 		instance_name = 'Naxxramas',
 		size = 10,
 		patterns = {
 			'naxx?1?0?' .. csep .. 'weekly',
-			'Anub\'Rekhan' .. wtext .. '!',
+			'Anub\'Rekhan' .. wtext .. '[!%]]',
 			create_quest_pattern(24580),
-			'Noth' .. wtext .. '!',
+			'Noth' .. wtext .. '[!%]]',
 			create_quest_pattern(24581),
-			'Razuvious' .. wtext .. '!',
+			'Razuvious' .. wtext .. '[!%]]',
 			create_quest_pattern(24582),
-			'Patchwerk' .. wtext .. '!',
+			'Patchwerk' .. wtext .. '[!%]]',
 			create_quest_pattern(24583),
 		},
-	},
-
-	{
-		name = 'eoe10',
-		instance_name = 'The Eye of Eternity',
-		size = 10,
-		patterns = std.algorithm.copy_back(
-			create_pattern_from_template('eoe', 10, 'simple'),
-			{
-				'malygo?s' .. csep .. '10',
-				'eoe' .. csep .. '10',
-				'A Poke In The Eye %(10 player%)',
-				create_achievement_pattern(1869),
-			}
-		),
 	},
 
 	{
@@ -496,7 +488,7 @@ local raid_list = {
 			create_pattern_from_template('eoe', 25, 'simple'),
 			{
 				'malygo?s' .. csep .. '25',
-				'eoe' .. csep .. '10',
+				'eoe' .. csep .. '25',
 				'A Poke In The Eye %(25 player%)',
 				create_achievement_pattern(1870),
 			}
@@ -504,12 +496,28 @@ local raid_list = {
 	},
 
 	{
+		name = 'eoe10',
+		instance_name = 'The Eye of Eternity',
+		size = 10,
+		patterns = std.algorithm.copy_back(
+			create_pattern_from_template('eoe', 10, 'simple'),
+			{
+				'malygo?s',
+				'eoe',
+				'A Poke In The Eye %(10 player%)',
+				create_achievement_pattern(1869),
+			}
+		),
+	},
+
+	{
 		name = 'eoe10wq',
+		prioritized = true,
 		instance_name = 'The Eye of Eternity',
 		size = 10,
 		patterns = {
 			'eoe1?0?' .. csep .. 'weekly',
-			'Malygos' .. wtext .. '!',
+			'Malygos' .. wtext .. '[!%]]',
 			create_quest_pattern(24584),
 		},
 	},
@@ -692,23 +700,21 @@ local role_patterns = {
 
 		'sh?a?d?o?w?' .. csep .. 'pri?e?st',
 		'pri?e?st' .. csep .. 'dps',
-		'sp',
+		'[^a-z]sp[^a-z]',
 
 		'elem?e?n?t?a?l?' .. csep .. 'shamm?[iy]?',
-		'mage',
+		'mage[^a-z]',
 
-		'boo?my?i?',
-		'boo?mki?n',
-		'boo?mi',
-		'boo?my',
-		'owl',
+		'boo?mm?[iy]?',
+		'boo?mm?ki?n',
+		'owl[^a-z]',
 		'ba?l?a?n?c?e?' .. csep .. 'd[ru][ud][iu]d?',
 
 		'rogu?e?' .. meta_or_sep,
 		'roug?e?' .. meta_or_sep,
 
 		'kitt?y',
-		'cat',
+		'cat[^a-z]',
 		'feral' .. csep .. 'cat' .. sep,
 		'feral' .. csep .. 'd?p?s?',
 
@@ -723,7 +729,8 @@ local role_patterns = {
 	},
 
 	healer = {
-		'h[ea][ea]?l[ers]*', -- LF healer
+		'h[ea][ea]l[ers]*', -- LF healer
+		'heler',
 
 		're?s?t?o?' .. csep .. 'd[ru][ud][iu]d?', -- LF rdruid/rdudu
 		meta_or_sep .. 'r' .. csep .. 'd[ru][ud][iu]d?', -- LF rdruid/rdudu
@@ -732,8 +739,8 @@ local role_patterns = {
 		're?s?t?o?' .. csep .. 'shamm?y?', -- LF rsham
 		meta_or_sep .. 'r' .. csep .. 'shamm?y?', -- LF rsham
 
-		'disco?' .. csep .. 'pri?e?st', -- disc priest
-		'dpri?e?st', -- disc priest
+		'disco?[^a-z]',
+		'dpri?e?st[^a-z]', -- disc priest
 		meta_or_sep .. 'd' .. csep .. 'pri?e?st', -- disc priest
 
 		'ho?l?l?y?' .. csep .. 'pala?d?i?n?', -- LF holy pala
@@ -744,7 +751,7 @@ local role_patterns = {
 		role_sep .. '[mo]t' .. role_sep, -- Need MT/OT
 		role_sep .. '[mo]t' .. csep .. '$', -- Need MT/OT
 		'ta*n+a?k+s?', -- NEED TANKS
-		'b[ea]*rs?',
+		'b[ea][ea]+rs?',
 		'prote?c?t?i?o?n?', -- NEED PROT PALA/WARRI
 	},
 }
@@ -848,48 +855,52 @@ local guild_patterns = {
 local lfg_patterns = {
 	'^' .. csep .. 'lfg' .. non_meta .. meta_raid,
 	'^' .. csep .. meta_gs .. non_meta .. meta_role .. non_meta .. 'looking' .. csep .. 'for' .. non_meta .. meta_raid,
-	'^' .. csep .. meta_role .. non_meta .. meta_gs .. non_meta .. 'looking' .. csep .. 'for' .. non_meta .. meta_raid,
+	meta_role .. non_meta .. meta_gs .. non_meta .. 'looking' .. csep .. 'for' .. non_meta .. meta_raid,
 
 	'^' .. csep .. meta_gs .. non_meta .. meta_role .. non_meta .. 'lf' .. non_meta .. meta_raid,
-	'^' .. csep .. meta_role .. non_meta .. meta_gs .. non_meta .. 'lf' .. non_meta .. meta_raid,
+	meta_role .. non_meta .. meta_gs .. non_meta .. 'lf' .. non_meta .. meta_raid,
 };
 
 ---@param message string
 ---@param patterns table
 ---@return boolean
 ---@nodiscard
-local function matches_any_pattern(message, patterns)
+local function matches_any_pattern(message, patterns, debug)
 	return std.algorithm.find_if(patterns, function(pattern)
-		return message:find(pattern);
+		local result = message:find(pattern)
+		if debug and result then
+			RaidBrowser:Print("Pattern matched: " .. pattern)
+		end
+		return result;
 	end) ~= nil;
 end
 
 ---@param message string
 ---@return boolean
 ---@nodiscard
-local function is_lfm_message(message)
-	return matches_any_pattern(message, lfm_patterns);
+local function is_lfm_message(message, debug)
+	return matches_any_pattern(message, lfm_patterns, debug);
 end
 
 ---@param message string
 ---@return boolean
 ---@nodiscard
-local function is_guild_recruitment(message)
-	return matches_any_pattern(message, guild_recruitment_patterns);
+local function is_guild_recruitment(message, debug)
+	return matches_any_pattern(message, guild_recruitment_patterns, debug);
 end
 
 ---@param message string
 ---@return boolean
 ---@nodiscard
-local function is_lfg_message(message)
-	return matches_any_pattern(message, lfg_patterns);
+local function is_lfg_message(message, debug)
+	return matches_any_pattern(message, lfg_patterns, debug);
 end
 
 ---@param message string
 ---@return boolean
 ---@nodiscard
-local function is_trade_message(message)
-	return matches_any_pattern(message, trade_message_patterns);
+local function is_trade_message(message, debug)
+	return matches_any_pattern(message, trade_message_patterns, debug);
 end
 
 -- Basic http pattern matching for streaming sites and etc.
@@ -925,13 +936,16 @@ end
 ---@param role "healer"|"dps"|"tank"
 ---@return table, string
 ---@nodiscard
-local function lex_roles(roles, message, role)
+local function lex_roles(roles, message, role, debug)
 	local found = false;
 
 	for _, pattern in ipairs(role_patterns[role]) do
 		local m, result = message:gsub(pattern, meta_role);
 
 		if result > 0 then
+			if debug then
+				RaidBrowser:Print('Role pattern found for '.. role .. ': ' .. pattern)
+			end
 			message = m;
 			found = true;
 		end
@@ -986,29 +1000,46 @@ end
 ---@param message string
 ---@return table?, string?, integer?
 ---@nodiscard
-function RaidBrowser.lex_raid_info(message)
+function RaidBrowser.lex_raid_info(message, debug)
 
 	local raid;
 	local num_unique_raids = 0;
+	local raid_pattern_index;
 	for _, r in ipairs(raid_list) do
+		local message_index;
 		local index = std.algorithm.find_if(r.patterns, function(pattern)
-			local m, result = message:gsub(pattern:lower(), meta_raid);
+			pattern = pattern:lower();
+			message_index = message:find(pattern);
+			
+			if message_index ~= nil then
+				local m, result = message:gsub(pattern, meta_raid);
 
-			if result > 0 then
-				message = m;
-				return true;
+				if result > 0 then
+					if debug then
+						RaidBrowser:Print("Raid found! " .. r.name .. ": " .. pattern);
+					end
+					message = m;
+					return true;
+				end
 			end
 
 			return false;
 		end);
 
 		if index then
-			-- only count as new unique raid, if previously found raid was a different size or zone
-			if not raid or (raid.size ~= r.size or RaidBrowser.get_short_raid_name(r.name) ~= RaidBrowser.get_short_raid_name(raid.name)) then
+			-- only count as new unique raid, if previously found raid was a different zone
+			if not raid or (RaidBrowser.get_short_raid_name(r.name) ~= RaidBrowser.get_short_raid_name(raid.name)) then
 				num_unique_raids = num_unique_raids + 1;
+				if debug and raid then
+					RaidBrowser:Print("Mutliple raids found! " .. r.name .. " - " .. raid.name)
+				end
 			end
-			-- but return last found raid to favor nm difficulty (hc achievements are often posted for nm raids, because once u have hc u cannot post the nm) and wq raids
-			raid = r;
+			
+			-- overwrite raid choice only if new raid is prioritized or found earlier in message (as people post hc achievements after declaring nm)
+			if (raid_pattern_index == nil or (raid and r.prioritized and not raid.prioritized) or raid_pattern_index > message_index) then
+				raid_pattern_index = message_index
+				raid = r;
+			end
 		end
 	end
 
@@ -1046,7 +1077,7 @@ end
 ---@param message any
 ---@return string?, table?, table?, string?
 ---@nodiscard
-function RaidBrowser.lex_and_extract(message)
+function RaidBrowser.lex_and_extract(message, debug)
 	if not message then return end
 	message = message:lower();
 	message = remove_http_links(message);
@@ -1062,7 +1093,7 @@ function RaidBrowser.lex_and_extract(message)
 	message = lex_guild_recruitments(message);
 
 	-- Get the raid_info from the message
-	local raid_info, raid_lexed_message, num_unique_raids = RaidBrowser.lex_raid_info(message);
+	local raid_info, raid_lexed_message, num_unique_raids = RaidBrowser.lex_raid_info(message, debug);
 	if not raid_info or not raid_lexed_message or not num_unique_raids then return end
 
 	if has_guild_recruitment_production(raid_lexed_message) then return end
@@ -1076,9 +1107,9 @@ function RaidBrowser.lex_and_extract(message)
 	local roles = {};
 
 	if not raid_lexed_message:find('lfm? all ') and not raid_lexed_message:find('nee?d all ') then
-		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'dps');
-		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'tank');
-		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'healer');
+		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'dps', debug);
+		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'tank', debug);
+		roles, raid_lexed_message = lex_roles(roles, raid_lexed_message, 'healer', debug);
 	end
 
 	-- If there is only an LFM message, then it is assumed that all roles are needed
@@ -1096,16 +1127,16 @@ end
 ---@param message string
 ---@return table?, table?, string?
 ---@nodiscard
-function RaidBrowser.raid_info(message)
-	local lexed_message, raid_info, roles, gs = RaidBrowser.lex_and_extract(message);
+function RaidBrowser.raid_info(message, debug)
+	local lexed_message, raid_info, roles, gs = RaidBrowser.lex_and_extract(message, debug);
 
 	if not lexed_message then return end
 
 	-- Any message that is lexed out to be an lfg is excluded (unfortunately near the end).
-	if is_lfg_message(lexed_message) then return end
+	if is_lfg_message(lexed_message, debug) then return end
 
 	-- Parse symbols to determine if the message is valid
-	if not is_lfm_message(lexed_message) then return end
+	if not is_lfm_message(lexed_message, debug) then return end
 
 	return raid_info, roles, gs or ' ';
 end

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -1109,6 +1109,10 @@ function RaidBrowser.raid_info(message)
 	return raid_info, roles, gs or ' ';
 end
 
+function RaidBrowser.get_short_raid_name(raid_name)
+	return string.gsub(raid_name, '[1|2][0|5](%w+)', '');
+end
+
 --[[ Event handlers and listeners ]] --
 RaidBrowserLfmChannelListeners = {
 	['CHAT_MSG_CHANNEL'] = {},

--- a/RaidBrowser/core.lua
+++ b/RaidBrowser/core.lua
@@ -26,6 +26,8 @@ local meta_or_sep = '[^' .. meta_char .. ']?' .. '[' .. sep .. ']?';
 
 local non_meta = '[^' .. meta_char .. ']*';
 
+local lfm = 'l[fm]%d*[fm]?'
+
 local function make_meta(text)
 	return meta_char .. text .. meta_char;
 end
@@ -101,6 +103,14 @@ local function create_pattern_from_template(raid_name_pattern, size, difficulty)
 	end);
 end
 
+local function create_achievement_pattern(achievement_id)
+	return "achievement:" .. tostring(achievement_id) .. ".+%]"
+end
+
+local function create_quest_pattern(quest_id)
+	return "quest:" .. tostring(quest_id) .. ".+%]"
+end
+
 local raid_list = {
 	-- Note: The order of each raid is deliberate.
 	-- Heroic raids are checked first, since NM raids will have the default 'icc10' pattern.
@@ -138,7 +148,14 @@ local raid_list = {
 		size = 10,
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('icc', 10, 'hc'),
-			{ 'bane of the fallen king' }
+			{ 
+				'Heroic: Storming the Citadel %(10 player%)',
+				create_achievement_pattern(4628),
+				'Bane of the Fallen King',
+				create_achievement_pattern(4583),
+				'Heroic: Fall of the Lich King %(10 player%)',
+				create_achievement_pattern(4636),
+			}
 		)
 	},
 
@@ -148,22 +165,60 @@ local raid_list = {
 		size = 25,
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('icc', 25, 'hc'),
-			{ 'the light of dawn' }
+			{ 
+				'Heroic: Storming the Citadel %(25 player%)',
+				create_achievement_pattern(4632),
+				'The Light of Dawn',
+				create_achievement_pattern(4584),
+				'Heroic: Fall of the Lich King %(25 player%)',
+				create_achievement_pattern(4637),
+			}
 		)
+	},
+
+	{
+		name = 'icc10wq',
+		instance_name = 'Icecrown Citadel',
+		size = 10,
+		patterns = {
+			'icc1?0?' .. csep .. 'weekly',
+			'Lord Marrowgar' .. wtext .. '!',
+			create_quest_pattern(24590),
+		},
 	},
 
 	{
 		name = 'icc10nm',
 		instance_name = 'Icecrown Citadel',
 		size = 10,
-		patterns = create_pattern_from_template('icc', 10, 'nm'),
+		patterns = std.algorithm.copy_back(
+			create_pattern_from_template('icc', 10, 'nm'),
+			{ 
+				'Storming the Citadel %(10 player%)',
+				create_achievement_pattern(4531),
+				'The Frozen Throne %(10 player%)',
+				create_achievement_pattern(4530),
+				'Fall of the Lich King %(10 player%)',
+				create_achievement_pattern(4532),
+			}
+		)
 	},
 
 	{
 		name = 'icc25nm',
 		instance_name = 'Icecrown Citadel',
 		size = 25,
-		patterns = create_pattern_from_template('icc', 25, 'nm'),
+		patterns = std.algorithm.copy_back(
+			create_pattern_from_template('icc', 25, 'nm'),
+			{ 
+				'Storming the Citadel %(25 player%)',
+				create_achievement_pattern(4604),
+				'The Frozen Throne %(25 player%)',
+				create_achievement_pattern(4597),
+				'Fall of the Lich King %(25 player%)',
+				create_achievement_pattern(4608),
+			}
+		)
 	},
 
 	{
@@ -174,7 +229,8 @@ local raid_list = {
 			create_pattern_from_template('toc', 10, 'hc'),
 			{
 				'togc' .. csep .. '10',
-				--'%[call of the grand crusade %(10 player%)%]'
+				'Call of the Grand Crusade %(10 player%)',
+				create_achievement_pattern(3918),
 			}-- Trial of the grand crusader (togc) refers to heroic toc
 		),
 	},
@@ -187,9 +243,21 @@ local raid_list = {
 			create_pattern_from_template('toc', 25, 'hc'),
 			{
 				'togc' .. csep .. '25',
-				--'%[call of the grand crusade %(25 player%)%]'
+				'Call of the Grand Crusade %(25 player%)',
+				create_achievement_pattern(3812),
 			}-- Trial of the grand crusader (togc) refers to heroic toc
 		),
+	},
+
+	{
+		name = 'toc10wq',
+		instance_name = 'Trial of the Crusader',
+		size = 10,
+		patterns = {
+			'tog?c1?0?' .. csep .. 'weekly',
+			'Lord Jaraxxus' .. wtext .. '!',
+			create_quest_pattern(24589),
+		},
 	},
 
 	{
@@ -198,7 +266,10 @@ local raid_list = {
 		size = 10,
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('toc', 10, 'nm'),
-			{ '%[call of the crusade %(10 player%)%]' }
+			{ 
+				'Call of the Crusade %(10 player%)',
+				create_achievement_pattern(3917),
+			}
 		),
 	},
 
@@ -208,7 +279,10 @@ local raid_list = {
 		size = 25,
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('toc', 25, 'nm'),
-			{ '%[call of the crusade %(25 player%)%]' }
+			{ 
+				'Call of the Crusade %(25 player%)',
+				create_achievement_pattern(3916),
+			}
 		),
 	},
 
@@ -216,7 +290,14 @@ local raid_list = {
 		name = 'rs10hc',
 		instance_name = 'The Ruby Sanctum',
 		size = 10,
-		patterns = create_pattern_from_template('rs', 10, 'hc')
+		patterns = std.algorithm.copy_back(
+			create_pattern_from_template('rs', 10, 'hc'),
+			{
+				'ruby' .. csep .. 'sanctum' .. csep .. 10,
+				'Heroic: The Twilight Destroyer %(10 player%)',
+				create_achievement_pattern(4818),
+			}
+		),
 	},
 
 	{
@@ -226,7 +307,8 @@ local raid_list = {
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('rs', 25, 'hc'),
 			{
-				'ruby' .. csep .. 'sanctum' .. csep .. 25
+				'Heroic: The Twilight Destroyer %(25 player%)',
+				create_achievement_pattern(4816),
 			}
 		),
 	},
@@ -238,7 +320,9 @@ local raid_list = {
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('rs', 10, 'nm'),
 			{
-				'ruby' .. csep .. 'sanctum' .. csep .. 10
+				'ruby' .. csep .. 'sanctum' .. csep .. 10,
+				'The Twilight Destroyer %(10 player%)',
+				create_achievement_pattern(4817),
 			}
 		),
 	},
@@ -248,8 +332,12 @@ local raid_list = {
 		instance_name = 'The Ruby Sanctum',
 		size = 25,
 		patterns = std.algorithm.copy_back(
-			{ ' rs 25n ' },
-			create_pattern_from_template('rs', 25, 'nm')
+			create_pattern_from_template('rs', 25, 'nm'),
+			{
+				'ruby' .. csep .. 'sanctum' .. csep .. 25,
+				'The Twilight Destroyer %(25 player%)',
+				create_achievement_pattern(4815),
+			}
 		)
 	},
 
@@ -268,11 +356,30 @@ local raid_list = {
 	},
 
 	{
+		name = 'ulduar10wq',
+		instance_name = 'Ulduar',
+		size = 10,
+		patterns = {
+			'ull?a?d[au]?[au]?r?1?0?' .. csep .. 'weekly',
+			'Flame Leviathan' .. wtext .. '!',
+			create_quest_pattern(24585),
+			'Ignis' .. wtext .. '!',
+			create_quest_pattern(24587),
+			'Razorscale' .. wtext .. '!',
+			create_quest_pattern(24586),
+			'XT-002' .. wtext .. '!',
+			create_quest_pattern(24588),
+		},
+	},
+
+	{
 		name = 'ulduar10',
 		instance_name = 'Ulduar',
 		size = 10,
 		patterns = {
 			'ull?a?d[au]?[au]?r?' .. csep .. '10',
+			'The Siege of Ulduar %(10 player%)',
+			create_achievement_pattern(2886),
 		},
 	},
 
@@ -282,6 +389,19 @@ local raid_list = {
 		size = 25,
 		patterns = {
 			'ull?a?d[au]?[au]?r?' .. csep .. '25',
+			'The Siege of Ulduar %(25 player%)',
+			create_achievement_pattern(2887),
+		}
+	},
+
+	{
+		name = 'os10wq',
+		instance_name = 'The Obsidian Sanctum',
+		size = 10,
+		patterns = {
+			'os1?0?' .. csep .. 'weekly',
+			'Sartharion' .. wtext .. '!',
+			create_quest_pattern(24579),
 		}
 	},
 
@@ -291,7 +411,10 @@ local raid_list = {
 		size = 10,
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('os', 10, 'simple'),
-			{ 'sartharion must die!' }
+			{ 
+				'Besting the Black Dragonflight %(10 player%)',
+				create_achievement_pattern(1876),
+			}
 		),
 	},
 
@@ -301,11 +424,28 @@ local raid_list = {
 		size = 25,
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('os', 25, 'simple'),
-			{
-				'%[sartharion must die!%]' .. csep .. '25',
-				csep .. '25' .. '%[sartharion must die%!%]',
+			{ 
+				'Besting the Black Dragonflight %(25 player%)',
+				create_achievement_pattern(625),
 			}
 		)
+	},
+
+	{
+		name = 'naxx10wq',
+		instance_name = 'Naxxramas',
+		size = 10,
+		patterns = {
+			'naxx?1?0?' .. csep .. 'weekly',
+			'Anub\'Rekhan' .. wtext .. '!',
+			create_quest_pattern(24580),
+			'Noth' .. wtext .. '!',
+			create_quest_pattern(24581),
+			'Razuvious' .. wtext .. '!',
+			create_quest_pattern(24582),
+			'Patchwerk' .. wtext .. '!',
+			create_quest_pattern(24583),
+		},
 	},
 
 	{
@@ -313,15 +453,10 @@ local raid_list = {
 		instance_name = 'Naxxramas',
 		size = 10,
 		patterns = {
-			'the fall of naxxramas %(10 player%)',
-			'noth' .. csep .. 'the' .. csep .. 'plaguebringer' .. csep .. 'must' .. csep .. 'die!',
-			'instructor' .. csep .. 'razuvious' .. csep .. 'must' .. csep .. 'die!',
+			'The Fall of Naxxramas %(10 player%)',
+			create_achievement_pattern(576),
 			'naxx?ramm?as' .. csep .. '10',
-			'anub\'rekhan' .. csep .. 'must' .. csep .. 'die!',
-			'patchwerk must die!',
 			'naxx?' .. csep .. '10',
-			'naxx' .. sep .. 'weekly',
-			'patchwerk' .. csep .. 'must' .. csep .. 'die!',
 		},
 	},
 
@@ -330,9 +465,21 @@ local raid_list = {
 		instance_name = 'Naxxramas',
 		size = 25,
 		patterns = {
-			'the fall of naxxramas %(25 player%)',
+			'The Fall of Naxxramas %(25 player%)',
+			create_achievement_pattern(577),
 			'naxx?ramm?as' .. csep .. '25',
 			'naxx?' .. csep .. '25',
+		},
+	},
+
+	{
+		name = 'eoe10wq',
+		instance_name = 'The Eye of Eternity',
+		size = 10,
+		patterns = {
+			'eoe1?0?' .. csep .. 'weekly',
+			'Malygos' .. wtext .. '!',
+			create_quest_pattern(24584),
 		},
 	},
 
@@ -343,8 +490,10 @@ local raid_list = {
 		patterns = std.algorithm.copy_back(
 			create_pattern_from_template('eoe', 10, 'simple'),
 			{
-				' eoe' .. csep .. '1?0?',
-				'malygo?s' .. csep .. '1?0?',
+				'malygo?s' .. csep .. '10',
+				'eoe' .. csep .. '10',
+				'A Poke In The Eye %(10 player%)',
+				create_achievement_pattern(1869),
 			}
 		),
 	},
@@ -357,6 +506,9 @@ local raid_list = {
 			create_pattern_from_template('eoe', 25, 'simple'),
 			{
 				'malygo?s' .. csep .. '25',
+				'eoe' .. csep .. '10',
+				'A Poke In The Eye %(25 player%)',
+				create_achievement_pattern(1870),
 			}
 		),
 	},
@@ -366,7 +518,8 @@ local raid_list = {
 		instance_name = 'Onyxia\'s Lair',
 		size = 25,
 		patterns = {
-			"onyxia's lair (25 player)",
+			'Onyxia\'s Lair %(25 player%)',
+			create_achievement_pattern(4397),
 			'onyx?i?a?' .. csep .. '25',
 		},
 	},
@@ -376,7 +529,8 @@ local raid_list = {
 		instance_name = 'Onyxia\'s Lair',
 		size = 10,
 		patterns = {
-			"onyxia's lair (10 player)",
+			'Onyxia\'s Lair %(10 player%)',
+			create_achievement_pattern(4396),
 			'onyx?i?a?' .. csep .. '10',
 		},
 	},
@@ -505,11 +659,23 @@ local raid_list = {
 
 	{
 		name = 'aq20',
-		instance_name = "Ruins of Ahn'Qiraj",
+		instance_name = 'Ruins of Ahn\'Qiraj',
 		size = 20,
 		patterns = {
 			'ruins?' .. csep .. 'of?' .. csep .. 'ahn\'?' .. csep .. 'qiraj',
 			'aq' .. csep .. '20',
+		},
+	},
+
+	-- WEEKLY raid fallback
+	{
+		name = 'weekly',
+		instance_name = 'Weekly Quest',
+		size = 10,
+		patterns = {
+			'weekly',
+			'we?ek?l?y?' .. csep .. 'raid',
+			'we?ek?l?y?' .. csep .. 'qu?e?s?t?',
 		},
 	},
 }
@@ -524,6 +690,7 @@ local role_patterns = {
 
 		'shadow' .. csep .. 'pri?e?st',
 		'pri?e?st' .. csep .. 'dps',
+		'sp',
 
 		'balance' .. '[ru][ud][iu]d?',
 
@@ -532,6 +699,9 @@ local role_patterns = {
 
 		'boo?my?i?',
 		'boo?mki?n',
+		'boo?mi',
+		'boo?my',
+		'owl',
 
 		'b[ru][ud][iu]d?',
 
@@ -539,6 +709,7 @@ local role_patterns = {
 		'rouge' .. meta_or_sep,
 
 		'kitt?y',
+		'cat',
 
 		'w?a?r?lock',
 
@@ -622,16 +793,16 @@ local rolelist_patterns = {
 };
 
 local lfm_patterns = {
-	'l[fm][fm]?' .. non_meta .. meta_role .. non_meta .. meta_raid,
+	lfm .. non_meta .. meta_role .. non_meta .. meta_raid,
 
 	meta_raid .. non_meta .. sep .. '[0-9]+' .. non_meta .. meta_role,
 
-	'lfm?' .. csep .. '[0-9]*' .. csep .. meta_role .. non_meta .. meta_gs .. '.*' .. meta_raid,
-	'lfm?' .. csep .. 'all' .. non_meta .. meta_raid,
+	lfm .. csep .. '[0-9]*' .. csep .. meta_role .. non_meta .. meta_gs .. '.*' .. meta_raid,
+	lfm .. csep .. 'all' .. non_meta .. meta_raid,
 	'need' .. csep .. 'all' .. non_meta .. meta_raid,
 	'seek' .. csep .. 'all' .. non_meta .. meta_raid,
 
-	meta_raid .. non_meta .. 'lfm?' .. csep .. 'all',
+	meta_raid .. non_meta .. lfm .. csep .. 'all',
 	meta_raid .. non_meta .. 'need' .. csep .. 'all',
 	meta_raid .. non_meta .. meta_gs .. non_meta .. 'lf' .. csep .. 'all',
 	meta_raid .. non_meta .. meta_gs .. non_meta .. 'seek' .. csep .. 'all',
@@ -641,7 +812,7 @@ local lfm_patterns = {
 	meta_raid .. non_meta .. 'need' .. non_meta .. meta_role,
 	meta_raid .. non_meta .. 'seek' .. non_meta .. meta_role,
 
-	meta_raid .. non_meta .. 'lfm?' .. non_meta .. meta_role,
+	meta_raid .. non_meta .. lfm .. non_meta .. meta_role,
 	meta_raid .. non_meta .. 'looki?ng' .. csep .. 'for' .. non_meta .. meta_role,
 
 	meta_raid .. non_meta .. 'need' .. csep .. 'all',
@@ -664,7 +835,7 @@ local lfm_patterns = {
 
 	meta_raid .. non_meta .. 'reserved',
 
-	'l[fm][fm]' .. non_meta .. meta_raid,
+	lfm .. non_meta .. meta_raid,
 
 	meta_raid .. non_meta .. meta_role,
 	'new' .. csep .. 'run' .. meta_raid,
@@ -826,7 +997,7 @@ function RaidBrowser.lex_raid_info(message)
 	local num_unique_raids = 0;
 	for _, r in ipairs(raid_list) do
 		local index = std.algorithm.find_if(r.patterns, function(pattern)
-			local m, result = message:gsub(pattern, meta_raid);
+			local m, result = message:gsub(pattern:lower(), meta_raid);
 
 			if result > 0 then
 				message = m;

--- a/RaidBrowser/stats.lua
+++ b/RaidBrowser/stats.lua
@@ -252,7 +252,7 @@ function RaidBrowser.stats.build_join_message(raid_name)
 	local message = 'inv for ' .. raid_name .. " - " .. gs .. 'gs ' .. spec;
 
 	-- Remove difficulty and raid_name size from the string
-	raid_name = string.gsub(raid_name, '[1|2][0|5](%w+)', '');
+	raid_name = RaidBrowser.get_short_raid_name(raid_name)
 
 	-- Find the best possible achievement for the given raid_name.
 	local achieve_id = find_best_achievement(raid_name);

--- a/tests/lfm_tests.lua
+++ b/tests/lfm_tests.lua
@@ -10,7 +10,7 @@ local test_cases = {
 	{
 		message = 'LF [Lord Marrowgar Must Die!] NEED ALL',
 		should_fail = false,
-		raid = 'icc10nm',
+		raid = 'icc10wq',
 		roles = { 'dps', 'tank', 'healer' },
 		gs = ' '
 	},
@@ -18,7 +18,7 @@ local test_cases = {
 	{
 		message = '1 GOOD TANK 2 HEALS AND A COUPLE DPS  [Anub\'Rekhan Must Die!] W/ GS AND ROLE EASY WEEKLY',
 		should_fail = false,
-		raid = 'naxx10',
+		raid = 'naxx10wq',
 		roles = { 'dps', 'tank', 'healer' },
 		gs = ' ',
 	},
@@ -26,7 +26,7 @@ local test_cases = {
 	{
 		message = 'LFM 1 GOOD TANK 2 HEALS 2 DPS  [Anub\'Rekhan Must Die!] EASY FAST WEEKLY W GS AND ROLE',
 		should_fail = false,
-		raid = 'naxx10',
+		raid = 'naxx10wq',
 		roles = { 'dps', 'tank', 'healer' },
 		gs = ' ',
 	},
@@ -77,7 +77,7 @@ local test_cases = {
 	{
 		message = 'Just Dps  [Sartharion Must Die!] >>>Bag Satchel Resserved <<<Dps need',
 		should_fail = false,
-		raid = 'os10',
+		raid = 'os10wq',
 		roles = { 'dps' },
 		gs = ' ',
 	},
@@ -146,7 +146,7 @@ local test_cases = {
 	{
 		message = 'OS10 NEED 1HEAL 2DPS	[Sartharion Must Die!]',
 		should_fail = false,
-		raid = 'os10',
+		raid = 'os10wq',
 		roles = { 'dps', 'healer' },
 		gs = ' ',
 	},
@@ -955,7 +955,7 @@ local test_cases = {
 	{
 		message = '[Sartharion Must Die!] OS 10 heal/dps 4.5k+',
 		should_fail = false,
-		raid = 'os10',
+		raid = 'os10wq',
 		roles = { 'healer', 'dps' },
 		gs = '4.5',
 	},
@@ -1071,7 +1071,7 @@ local test_cases = {
 	{
 		message = 'LFM  [Anub\'Rekhan Must Die!] NEED ALL',
 		should_fail = false,
-		raid = 'naxx10',
+		raid = 'naxx10wq',
 		roles = { 'dps', 'healer', 'tank' },
 		gs = ' ',
 	},
@@ -1331,7 +1331,7 @@ local test_cases = {
 	{
 		message = 'NEW RUN [Sartharion Must Die!] 25er w me info !!',
 		should_fail = false,
-		raid = 'os25',
+		raid = 'os25wq',
 		roles = { 'tank', 'dps', 'healer' },
 		gs = ' ',
 	},
@@ -1398,7 +1398,7 @@ local test_cases = {
 	{
 		message = 'LFM 10 man [Sartharion Must Die] - Need 1x Tank & 2x DPS - (Can share quest) Group Loot',
 		should_fail = false,
-		raid = 'os10',
+		raid = 'os10wq',
 		roles = { 'tank', 'dps' },
 		gs = ' '
 	},
@@ -1527,7 +1527,9 @@ end
 
 ---@param test table
 local function run_test_case(test)
-	local raid_info, roles, gs = RaidBrowser.raid_info(test.message)
+	local verbose_logging = true
+	RaidBrowser.Print("Testing: " .. test.message)
+	local raid_info, roles, gs = RaidBrowser.raid_info(test.message, verbose_logging)
 
 	local detected = nil;
 	if raid_info and roles and gs then
@@ -1566,14 +1568,29 @@ local function run_test_case(test)
 		end
 	end
 
+	RaidBrowser.Print("Test successful!")
+
 	return true;
 end
 
--- Run all the test cases
-local test_results = std.algorithm.transform(test_cases, run_test_case);
+RaidBrowser.test = function(m)
+	if m == nil then
+		-- Run all the test cases
+		local test_results = std.algorithm.transform(test_cases, run_test_case);
+		
+		-- Count the number of failed tests.
+		local number_failed_tests = #test_cases - std.algorithm.count(test_results, true);
+		
+		RaidBrowser:Print('All unit tests executed.');
+		RaidBrowser:Print('There were ' .. number_failed_tests .. '/' .. #test_cases .. ' failed unit tests!');
+		print('There were ' .. number_failed_tests .. '/' .. #test_cases .. ' failed unit tests!')
+	else
+		local test = {}
+		test.message = m
+		test.should_fail = true
+		run_test_case(test)
+		RaidBrowser:Print('Test executed.');
+	end
+end
 
--- Count the number of failed tests.
-local number_failed_tests = #test_cases - std.algorithm.count(test_results, true);
-
-RaidBrowser:Print('All unit tests executed.');
-RaidBrowser:Print('There were ' .. number_failed_tests .. '/' .. #test_cases .. ' failed unit tests!');
+RaidBrowser.test()


### PR DESCRIPTION
I noticed only some of the often posted weekly quests and achievements are being parsed, so I put some work into improving this.

These changes will also support localized clients, since both, english quest/achievement title and actual ID in links are compared.
While working on this I also noticed that LF5M or alike are not being processed, so that is fixed as well.

improve parsing weekly quest raid messages,
add new category for weekly quest raids (wq),
improve parsing achievement quest raid messages,
improve parsing lfm (including LF5M etc),
add some missing dps patterns